### PR TITLE
Cuda tromp should be default solver

### DIFF
--- a/zhasher/main.cpp
+++ b/zhasher/main.cpp
@@ -53,7 +53,7 @@ namespace keywords = boost::log::keywords;
 
 int use_avx = 0;
 int use_avx2 = 0;
-int use_old_cuda = 0;
+int use_old_cuda = 1;
 int use_old_xmp = 0;
 
 // TODO move somwhere else


### PR DESCRIPTION
This commit makes cuda tromp the default solver to hopefully lower the
barrier of entry for new miners.y